### PR TITLE
feat: rotation - fila circular de pagadores

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -38,6 +38,10 @@ func (app *application) mount() http.Handler {
 
 			r.Get("/config", app.configHandler.GetAll)
 			r.With(handler.AdminOnly).Put("/config", app.configHandler.Update)
+
+			r.Get("/rotation", app.rotationHandler.GetCurrent)
+			r.With(handler.AdminOnly).Put("/rotation/order", app.rotationHandler.UpdateOrder)
+			r.With(handler.AdminOnly).Post("/rotation/skip", app.rotationHandler.Skip)
 		})
 	})
 
@@ -62,10 +66,11 @@ func (app *application) run(h http.Handler) error {
 }
 
 type application struct {
-	config        config
-	userHandler   *handler.UserHandler
-	authHandler   *handler.AuthHandler
-	configHandler *handler.ConfigHandler
+	config          config
+	userHandler     *handler.UserHandler
+	authHandler     *handler.AuthHandler
+	configHandler   *handler.ConfigHandler
+	rotationHandler *handler.RotationHandler
 }
 
 type config struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,10 @@ func main() {
 	configUC      := usecase.NewConfigUseCase(configRepo)
 	configHandler := handler.NewConfigHandler(configUC)
 
+	rotationRepo    := postgres.NewRotationRepository(gormDB)
+	rotationUC      := usecase.NewRotationUseCase(rotationRepo, userRepo)
+	rotationHandler := handler.NewRotationHandler(rotationUC)
+
 	cfg := &config{
 		addr:      ":8080",
 		db:        dbConfig{dsn: dsn},
@@ -65,10 +69,11 @@ func main() {
 	}
 
 	api := &application{
-		config:        *cfg,
-		userHandler:   userHandler,
-		authHandler:   authHandler,
-		configHandler: configHandler,
+		config:          *cfg,
+		userHandler:     userHandler,
+		authHandler:     authHandler,
+		configHandler:   configHandler,
+		rotationHandler: rotationHandler,
 	}
 
 	if err := api.run(api.mount()); err != nil {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -229,6 +229,143 @@ const docTemplate = `{
                 }
             }
         },
+        "/rotation": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a fila circular de pagadores com a posição atual",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Listar rodízio atual",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.RotationResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rotation/order": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Substitui a fila de pagadores (somente admin)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Atualizar ordem do rodízio",
+                "parameters": [
+                    {
+                        "description": "Array completo de user_ids na nova ordem",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.updateOrderRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "admin role required",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
+        "/rotation/skip": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Avança a posição atual da fila para o próximo usuário (somente admin)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Pular vez no rodízio",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "admin role required",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "rotation not initialized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "description": "Cria um novo usuário com email e senha",
@@ -290,6 +427,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RotationMember": {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "integer"
+                },
+                "user_id": {
                     "type": "string"
                 }
             }
@@ -445,6 +593,34 @@ const docTemplate = `{
                 },
                 "value": {
                     "type": "string"
+                }
+            }
+        },
+        "http.updateOrderRequest": {
+            "type": "object",
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "usecase.RotationResponse": {
+            "type": "object",
+            "properties": {
+                "current_payer_id": {
+                    "type": "string"
+                },
+                "current_pos": {
+                    "type": "integer"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.RotationMember"
+                    }
                 }
             }
         }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -223,6 +223,143 @@
                 }
             }
         },
+        "/rotation": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a fila circular de pagadores com a posição atual",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Listar rodízio atual",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.RotationResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rotation/order": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Substitui a fila de pagadores (somente admin)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Atualizar ordem do rodízio",
+                "parameters": [
+                    {
+                        "description": "Array completo de user_ids na nova ordem",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/http.updateOrderRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "admin role required",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
+        "/rotation/skip": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Avança a posição atual da fila para o próximo usuário (somente admin)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rotation"
+                ],
+                "summary": "Pular vez no rodízio",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "admin role required",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "rotation not initialized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "description": "Cria um novo usuário com email e senha",
@@ -284,6 +421,17 @@
                     "type": "string"
                 },
                 "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RotationMember": {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "integer"
+                },
+                "user_id": {
                     "type": "string"
                 }
             }
@@ -439,6 +587,34 @@
                 },
                 "value": {
                     "type": "string"
+                }
+            }
+        },
+        "http.updateOrderRequest": {
+            "type": "object",
+            "properties": {
+                "user_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "usecase.RotationResponse": {
+            "type": "object",
+            "properties": {
+                "current_payer_id": {
+                    "type": "string"
+                },
+                "current_pos": {
+                    "type": "integer"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.RotationMember"
+                    }
                 }
             }
         }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -7,6 +7,13 @@ definitions:
       value:
         type: string
     type: object
+  domain.RotationMember:
+    properties:
+      position:
+        type: integer
+      user_id:
+        type: string
+    type: object
   domain.User:
     properties:
       created_at:
@@ -108,6 +115,24 @@ definitions:
         type: string
       value:
         type: string
+    type: object
+  http.updateOrderRequest:
+    properties:
+      user_ids:
+        items:
+          type: string
+        type: array
+    type: object
+  usecase.RotationResponse:
+    properties:
+      current_payer_id:
+        type: string
+      current_pos:
+        type: integer
+      members:
+        items:
+          $ref: '#/definitions/domain.RotationMember'
+        type: array
     type: object
 host: localhost:8080
 info:
@@ -254,6 +279,93 @@ paths:
       summary: Atualizar configuração
       tags:
       - config
+  /rotation:
+    get:
+      description: Retorna a fila circular de pagadores com a posição atual
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/usecase.RotationResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+      security:
+      - BearerAuth: []
+      summary: Listar rodízio atual
+      tags:
+      - rotation
+  /rotation/order:
+    put:
+      consumes:
+      - application/json
+      description: Substitui a fila de pagadores (somente admin)
+      parameters:
+      - description: Array completo de user_ids na nova ordem
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/http.updateOrderRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+        "403":
+          description: admin role required
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+      security:
+      - BearerAuth: []
+      summary: Atualizar ordem do rodízio
+      tags:
+      - rotation
+  /rotation/skip:
+    post:
+      description: Avança a posição atual da fila para o próximo usuário (somente
+        admin)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+        "403":
+          description: admin role required
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "409":
+          description: rotation not initialized
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+      security:
+      - BearerAuth: []
+      summary: Pular vez no rodízio
+      tags:
+      - rotation
   /users:
     post:
       consumes:

--- a/internal/domain/rotation.go
+++ b/internal/domain/rotation.go
@@ -1,0 +1,40 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrRotationNotInitialized = errors.New("rotation not initialized")
+	ErrRotationEmptyOrder     = errors.New("rotation order cannot be empty")
+	ErrRotationDuplicateUser  = errors.New("rotation order contains duplicate users")
+	ErrRotationUnknownUser    = errors.New("rotation order contains unknown user")
+)
+
+type RotationMember struct {
+	UserID   string `json:"user_id"`
+	Position int    `json:"position"`
+}
+
+type Rotation struct {
+	ID         string            `json:"id"`
+	CurrentPos int               `json:"current_pos"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+	Members    []*RotationMember `json:"members"`
+}
+
+// CurrentPayerID returns the user_id at current_pos.
+// Members must be sorted by position (0..n-1) — the repository guarantees this.
+func (r *Rotation) CurrentPayerID() string {
+	if len(r.Members) == 0 || r.CurrentPos >= len(r.Members) {
+		return ""
+	}
+	return r.Members[r.CurrentPos].UserID
+}
+
+type RotationRepository interface {
+	Get() (*Rotation, error)         // returns nil if no rotation exists yet
+	SetOrder(userIDs []string) error // full replacement + resets current_pos to 0
+	AdvancePosition() error          // circular increment of current_pos
+}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -34,4 +34,6 @@ type UserRepository interface {
 	Create(user *User) error
 	FindByEmail(email string) (*User, error)
 	FindByProviderID(provider, providerID string) (*User, error)
+	FindByID(id string) (*User, error)
+	FindAll() ([]*User, error)
 }

--- a/internal/handler/http/rotation.go
+++ b/internal/handler/http/rotation.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+type RotationHandler struct {
+	uc *usecase.RotationUseCase
+}
+
+func NewRotationHandler(uc *usecase.RotationUseCase) *RotationHandler {
+	return &RotationHandler{uc: uc}
+}
+
+type updateOrderRequest struct {
+	UserIDs []string `json:"user_ids"`
+}
+
+// GetCurrent godoc
+// @Summary      Listar rodízio atual
+// @Description  Retorna a fila circular de pagadores com a posição atual
+// @Tags         rotation
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  usecase.RotationResponse
+// @Failure      401  {object}  ErrInvalidCredentials
+// @Router       /rotation [get]
+func (h *RotationHandler) GetCurrent(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.uc.GetCurrent()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// UpdateOrder godoc
+// @Summary      Atualizar ordem do rodízio
+// @Description  Substitui a fila de pagadores (somente admin)
+// @Tags         rotation
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        body  body      updateOrderRequest  true  "Array completo de user_ids na nova ordem"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  ErrValidation
+// @Failure      401   {object}  ErrInvalidCredentials
+// @Failure      403   {object}  ErrValidation  "admin role required"
+// @Router       /rotation/order [put]
+func (h *RotationHandler) UpdateOrder(w http.ResponseWriter, r *http.Request) {
+	var req updateOrderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "invalid request body")
+		return
+	}
+
+	if err := h.uc.UpdateOrder(req.UserIDs); err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRotationEmptyOrder),
+			errors.Is(err, domain.ErrRotationDuplicateUser),
+			errors.Is(err, domain.ErrRotationUnknownUser):
+			writeError(w, http.StatusBadRequest, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"message": "rotation order updated"})
+}
+
+// Skip godoc
+// @Summary      Pular vez no rodízio
+// @Description  Avança a posição atual da fila para o próximo usuário (somente admin)
+// @Tags         rotation
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  map[string]string
+// @Failure      401  {object}  ErrInvalidCredentials
+// @Failure      403  {object}  ErrValidation  "admin role required"
+// @Failure      409  {object}  ErrValidation  "rotation not initialized"
+// @Router       /rotation/skip [post]
+func (h *RotationHandler) Skip(w http.ResponseWriter, r *http.Request) {
+	if err := h.uc.Skip(); err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRotationNotInitialized):
+			writeError(w, http.StatusConflict, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"message": "rotation advanced"})
+}

--- a/internal/handler/http/rotation_test.go
+++ b/internal/handler/http/rotation_test.go
@@ -1,0 +1,179 @@
+package http_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	handler "github.com/antoniobt12062002/pao-de-queijo/internal/handler/http"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+// --- stubs ---
+
+type stubRotationRepo struct {
+	rotation *domain.Rotation
+}
+
+func newStubRotationRepo() *stubRotationRepo {
+	return &stubRotationRepo{}
+}
+
+func (s *stubRotationRepo) Get() (*domain.Rotation, error) {
+	return s.rotation, nil
+}
+
+func (s *stubRotationRepo) SetOrder(userIDs []string) error {
+	members := make([]*domain.RotationMember, len(userIDs))
+	for i, id := range userIDs {
+		members[i] = &domain.RotationMember{UserID: id, Position: i}
+	}
+	if s.rotation == nil {
+		s.rotation = &domain.Rotation{ID: "test-rotation", CurrentPos: 0}
+	} else {
+		s.rotation.CurrentPos = 0
+	}
+	s.rotation.Members = members
+	return nil
+}
+
+func (s *stubRotationRepo) AdvancePosition() error {
+	if s.rotation == nil || len(s.rotation.Members) == 0 {
+		return domain.ErrRotationNotInitialized
+	}
+	s.rotation.CurrentPos = (s.rotation.CurrentPos + 1) % len(s.rotation.Members)
+	return nil
+}
+
+type stubUserRepoForRotation struct {
+	users []*domain.User
+}
+
+func newStubUserRepoForRotation(ids ...string) *stubUserRepoForRotation {
+	users := make([]*domain.User, len(ids))
+	for i, id := range ids {
+		users[i] = &domain.User{ID: id, Name: "User", Email: id + "@test.com"}
+	}
+	return &stubUserRepoForRotation{users: users}
+}
+
+func (s *stubUserRepoForRotation) Create(u *domain.User) error                             { return nil }
+func (s *stubUserRepoForRotation) FindByEmail(email string) (*domain.User, error)          { return nil, nil }
+func (s *stubUserRepoForRotation) FindByProviderID(p, id string) (*domain.User, error)     { return nil, nil }
+func (s *stubUserRepoForRotation) FindByID(id string) (*domain.User, error)                { return nil, nil }
+func (s *stubUserRepoForRotation) FindAll() ([]*domain.User, error)                        { return s.users, nil }
+
+// --- tests ---
+
+func TestRotationHandler_GetCurrent_Empty(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), newStubUserRepoForRotation())
+	h := handler.NewRotationHandler(uc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rotation", nil)
+	w := httptest.NewRecorder()
+	h.GetCurrent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	members, _ := resp["members"].([]any)
+	if len(members) != 0 {
+		t.Errorf("expected empty members, got %d", len(members))
+	}
+}
+
+func TestRotationHandler_UpdateOrder_Valid(t *testing.T) {
+	userRepo := newStubUserRepoForRotation("user-1", "user-2")
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), userRepo)
+	h := handler.NewRotationHandler(uc)
+
+	body := `{"user_ids":["user-1","user-2"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/rotation/order", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateOrder(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRotationHandler_UpdateOrder_Empty(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), newStubUserRepoForRotation())
+	h := handler.NewRotationHandler(uc)
+
+	body := `{"user_ids":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/rotation/order", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateOrder(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRotationHandler_UpdateOrder_Duplicates(t *testing.T) {
+	userRepo := newStubUserRepoForRotation("user-1")
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), userRepo)
+	h := handler.NewRotationHandler(uc)
+
+	body := `{"user_ids":["user-1","user-1"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/rotation/order", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateOrder(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRotationHandler_UpdateOrder_UnknownUser(t *testing.T) {
+	userRepo := newStubUserRepoForRotation("user-1")
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), userRepo)
+	h := handler.NewRotationHandler(uc)
+
+	body := `{"user_ids":["user-1","unknown-id"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/rotation/order", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateOrder(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRotationHandler_Skip_Valid(t *testing.T) {
+	repo := newStubRotationRepo()
+	_ = repo.SetOrder([]string{"user-1", "user-2"})
+	uc := usecase.NewRotationUseCase(repo, newStubUserRepoForRotation("user-1", "user-2"))
+	h := handler.NewRotationHandler(uc)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/rotation/skip", nil)
+	w := httptest.NewRecorder()
+	h.Skip(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRotationHandler_Skip_NotInitialized(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newStubRotationRepo(), newStubUserRepoForRotation())
+	h := handler.NewRotationHandler(uc)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/rotation/skip", nil)
+	w := httptest.NewRecorder()
+	h.Skip(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}

--- a/internal/handler/http/user_test.go
+++ b/internal/handler/http/user_test.go
@@ -22,6 +22,8 @@ func (s *stubRepo) Create(u *domain.User) error {
 }
 func (s *stubRepo) FindByEmail(e string) (*domain.User, error) { u := s.users[e]; return u, nil }
 func (s *stubRepo) FindByProviderID(p, id string) (*domain.User, error) { return nil, nil }
+func (s *stubRepo) FindByID(id string) (*domain.User, error)            { return nil, nil }
+func (s *stubRepo) FindAll() ([]*domain.User, error)                    { return nil, nil }
 
 func TestRegisterHandler(t *testing.T) {
 	uc := usecase.NewUserUseCase(newStubRepo(), "secret")

--- a/internal/repository/postgres/rotation.go
+++ b/internal/repository/postgres/rotation.go
@@ -1,0 +1,120 @@
+package postgres
+
+import (
+	"errors"
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"gorm.io/gorm"
+)
+
+type rotationModel struct {
+	ID         string    `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+	CurrentPos int       `gorm:"column:current_pos"`
+	UpdatedAt  time.Time `gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (rotationModel) TableName() string { return "rotations" }
+
+type rotationMemberModel struct {
+	RotationID string `gorm:"column:rotation_id"`
+	UserID     string `gorm:"column:user_id"`
+	Position   int    `gorm:"column:position"`
+}
+
+func (rotationMemberModel) TableName() string { return "rotation_members" }
+
+type RotationRepository struct {
+	db *gorm.DB
+}
+
+func NewRotationRepository(db *gorm.DB) *RotationRepository {
+	return &RotationRepository{db: db}
+}
+
+func (r *RotationRepository) Get() (*domain.Rotation, error) {
+	var rm rotationModel
+	result := r.db.First(&rm)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	var memberModels []rotationMemberModel
+	if err := r.db.Where("rotation_id = ?", rm.ID).Order("position ASC").Find(&memberModels).Error; err != nil {
+		return nil, err
+	}
+
+	members := make([]*domain.RotationMember, len(memberModels))
+	for i, m := range memberModels {
+		members[i] = &domain.RotationMember{UserID: m.UserID, Position: m.Position}
+	}
+
+	return &domain.Rotation{
+		ID:         rm.ID,
+		CurrentPos: rm.CurrentPos,
+		UpdatedAt:  rm.UpdatedAt,
+		Members:    members,
+	}, nil
+}
+
+func (r *RotationRepository) SetOrder(userIDs []string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// Upsert rotation singleton
+		var rm rotationModel
+		result := tx.First(&rm)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			rm = rotationModel{CurrentPos: 0}
+			if err := tx.Create(&rm).Error; err != nil {
+				return err
+			}
+		} else if result.Error != nil {
+			return result.Error
+		} else {
+			if err := tx.Model(&rm).Update("current_pos", 0).Error; err != nil {
+				return err
+			}
+		}
+
+		// Delete all existing members for this rotation
+		if err := tx.Where("rotation_id = ?", rm.ID).Delete(&rotationMemberModel{}).Error; err != nil {
+			return err
+		}
+
+		// Insert new members
+		members := make([]rotationMemberModel, len(userIDs))
+		for i, uid := range userIDs {
+			members[i] = rotationMemberModel{
+				RotationID: rm.ID,
+				UserID:     uid,
+				Position:   i,
+			}
+		}
+		return tx.Create(&members).Error
+	})
+}
+
+func (r *RotationRepository) AdvancePosition() error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var rm rotationModel
+		if err := tx.First(&rm).Error; err != nil {
+			return err
+		}
+
+		var count int64
+		if err := tx.Model(&rotationMemberModel{}).Where("rotation_id = ?", rm.ID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			return domain.ErrRotationNotInitialized
+		}
+
+		nextPos := (rm.CurrentPos + 1) % int(count)
+		return tx.Model(&rm).Update("current_pos", nextPos).Error
+	})
+}
+
+// Verify interface compliance at compile time
+var _ domain.RotationRepository = (*RotationRepository)(nil)

--- a/internal/repository/postgres/user.go
+++ b/internal/repository/postgres/user.go
@@ -67,6 +67,30 @@ func (r *UserRepository) FindByProviderID(provider, providerID string) (*domain.
 	return toDomain(&m), nil
 }
 
+func (r *UserRepository) FindByID(id string) (*domain.User, error) {
+	var m userModel
+	result := r.db.Where("id = ?", id).First(&m)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return toDomain(&m), nil
+}
+
+func (r *UserRepository) FindAll() ([]*domain.User, error) {
+	var models []userModel
+	if err := r.db.Find(&models).Error; err != nil {
+		return nil, err
+	}
+	users := make([]*domain.User, len(models))
+	for i, m := range models {
+		users[i] = toDomain(&m)
+	}
+	return users, nil
+}
+
 func toModel(u *domain.User) *userModel {
 	return &userModel{
 		ID:           u.ID,

--- a/internal/usecase/rotation.go
+++ b/internal/usecase/rotation.go
@@ -1,0 +1,77 @@
+package usecase
+
+import "github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+
+type RotationUseCase struct {
+	repo     domain.RotationRepository
+	userRepo domain.UserRepository
+}
+
+func NewRotationUseCase(repo domain.RotationRepository, userRepo domain.UserRepository) *RotationUseCase {
+	return &RotationUseCase{repo: repo, userRepo: userRepo}
+}
+
+// RotationResponse is the response type returned by GetCurrent.
+type RotationResponse struct {
+	CurrentPos     int                      `json:"current_pos"`
+	CurrentPayerID string                   `json:"current_payer_id"`
+	Members        []*domain.RotationMember `json:"members"`
+}
+
+func (uc *RotationUseCase) GetCurrent() (*RotationResponse, error) {
+	r, err := uc.repo.Get()
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return &RotationResponse{Members: []*domain.RotationMember{}}, nil
+	}
+	return &RotationResponse{
+		CurrentPos:     r.CurrentPos,
+		CurrentPayerID: r.CurrentPayerID(),
+		Members:        r.Members,
+	}, nil
+}
+
+func (uc *RotationUseCase) UpdateOrder(userIDs []string) error {
+	if len(userIDs) == 0 {
+		return domain.ErrRotationEmptyOrder
+	}
+
+	// Check for duplicates
+	seen := make(map[string]bool, len(userIDs))
+	for _, id := range userIDs {
+		if seen[id] {
+			return domain.ErrRotationDuplicateUser
+		}
+		seen[id] = true
+	}
+
+	// Validate all users exist
+	allUsers, err := uc.userRepo.FindAll()
+	if err != nil {
+		return err
+	}
+	validIDs := make(map[string]bool, len(allUsers))
+	for _, u := range allUsers {
+		validIDs[u.ID] = true
+	}
+	for _, id := range userIDs {
+		if !validIDs[id] {
+			return domain.ErrRotationUnknownUser
+		}
+	}
+
+	return uc.repo.SetOrder(userIDs)
+}
+
+func (uc *RotationUseCase) Skip() error {
+	r, err := uc.repo.Get()
+	if err != nil {
+		return err
+	}
+	if r == nil || len(r.Members) == 0 {
+		return domain.ErrRotationNotInitialized
+	}
+	return uc.repo.AdvancePosition()
+}

--- a/internal/usecase/rotation_test.go
+++ b/internal/usecase/rotation_test.go
@@ -1,0 +1,188 @@
+package usecase_test
+
+import (
+	"testing"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+// --- mocks ---
+
+type mockRotationRepo struct {
+	rotation *domain.Rotation
+}
+
+func newMockRotationRepo() *mockRotationRepo {
+	return &mockRotationRepo{}
+}
+
+func (m *mockRotationRepo) Get() (*domain.Rotation, error) {
+	return m.rotation, nil
+}
+
+func (m *mockRotationRepo) SetOrder(userIDs []string) error {
+	members := make([]*domain.RotationMember, len(userIDs))
+	for i, id := range userIDs {
+		members[i] = &domain.RotationMember{UserID: id, Position: i}
+	}
+	if m.rotation == nil {
+		m.rotation = &domain.Rotation{ID: "rotation-uuid", CurrentPos: 0}
+	} else {
+		m.rotation.CurrentPos = 0
+	}
+	m.rotation.Members = members
+	return nil
+}
+
+func (m *mockRotationRepo) AdvancePosition() error {
+	if m.rotation == nil || len(m.rotation.Members) == 0 {
+		return domain.ErrRotationNotInitialized
+	}
+	m.rotation.CurrentPos = (m.rotation.CurrentPos + 1) % len(m.rotation.Members)
+	return nil
+}
+
+type mockUserRepoForRotation struct {
+	users []*domain.User
+}
+
+func newMockUserRepoForRotation(ids ...string) *mockUserRepoForRotation {
+	users := make([]*domain.User, len(ids))
+	for i, id := range ids {
+		users[i] = &domain.User{ID: id, Name: "User " + id, Email: id + "@test.com"}
+	}
+	return &mockUserRepoForRotation{users: users}
+}
+
+func (m *mockUserRepoForRotation) Create(u *domain.User) error                              { return nil }
+func (m *mockUserRepoForRotation) FindByEmail(email string) (*domain.User, error)           { return nil, nil }
+func (m *mockUserRepoForRotation) FindByProviderID(p, id string) (*domain.User, error)      { return nil, nil }
+func (m *mockUserRepoForRotation) FindByID(id string) (*domain.User, error)                 { return nil, nil }
+func (m *mockUserRepoForRotation) FindAll() ([]*domain.User, error) {
+	return m.users, nil
+}
+
+// --- tests ---
+
+func TestRotationUseCase_GetCurrent_Empty(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newMockRotationRepo(), newMockUserRepoForRotation())
+	resp, err := uc.GetCurrent()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(resp.Members) != 0 {
+		t.Errorf("expected empty members, got %d", len(resp.Members))
+	}
+	if resp.CurrentPayerID != "" {
+		t.Errorf("expected empty payer id, got %q", resp.CurrentPayerID)
+	}
+}
+
+func TestRotationUseCase_GetCurrent_Initialized(t *testing.T) {
+	repo := newMockRotationRepo()
+	_ = repo.SetOrder([]string{"user-1", "user-2", "user-3"})
+	repo.rotation.CurrentPos = 1
+
+	uc := usecase.NewRotationUseCase(repo, newMockUserRepoForRotation("user-1", "user-2", "user-3"))
+	resp, err := uc.GetCurrent()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp.CurrentPayerID != "user-2" {
+		t.Errorf("expected current payer to be user-2, got %q", resp.CurrentPayerID)
+	}
+	if len(resp.Members) != 3 {
+		t.Errorf("expected 3 members, got %d", len(resp.Members))
+	}
+}
+
+func TestRotationUseCase_UpdateOrder_Valid(t *testing.T) {
+	repo := newMockRotationRepo()
+	userRepo := newMockUserRepoForRotation("user-1", "user-2", "user-3")
+	uc := usecase.NewRotationUseCase(repo, userRepo)
+
+	err := uc.UpdateOrder([]string{"user-1", "user-2", "user-3"})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(repo.rotation.Members) != 3 {
+		t.Errorf("expected 3 members, got %d", len(repo.rotation.Members))
+	}
+	if repo.rotation.CurrentPos != 0 {
+		t.Errorf("expected current_pos reset to 0, got %d", repo.rotation.CurrentPos)
+	}
+}
+
+func TestRotationUseCase_UpdateOrder_Empty(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newMockRotationRepo(), newMockUserRepoForRotation())
+	err := uc.UpdateOrder([]string{})
+	if err == nil {
+		t.Fatal("expected error for empty order, got nil")
+	}
+	if err != domain.ErrRotationEmptyOrder {
+		t.Errorf("expected ErrRotationEmptyOrder, got: %v", err)
+	}
+}
+
+func TestRotationUseCase_UpdateOrder_Duplicates(t *testing.T) {
+	userRepo := newMockUserRepoForRotation("user-1", "user-2")
+	uc := usecase.NewRotationUseCase(newMockRotationRepo(), userRepo)
+	err := uc.UpdateOrder([]string{"user-1", "user-1"})
+	if err == nil {
+		t.Fatal("expected error for duplicate user, got nil")
+	}
+	if err != domain.ErrRotationDuplicateUser {
+		t.Errorf("expected ErrRotationDuplicateUser, got: %v", err)
+	}
+}
+
+func TestRotationUseCase_UpdateOrder_UnknownUser(t *testing.T) {
+	userRepo := newMockUserRepoForRotation("user-1", "user-2")
+	uc := usecase.NewRotationUseCase(newMockRotationRepo(), userRepo)
+	err := uc.UpdateOrder([]string{"user-1", "unknown-user"})
+	if err == nil {
+		t.Fatal("expected error for unknown user, got nil")
+	}
+	if err != domain.ErrRotationUnknownUser {
+		t.Errorf("expected ErrRotationUnknownUser, got: %v", err)
+	}
+}
+
+func TestRotationUseCase_Skip_NotInitialized(t *testing.T) {
+	uc := usecase.NewRotationUseCase(newMockRotationRepo(), newMockUserRepoForRotation())
+	err := uc.Skip()
+	if err == nil {
+		t.Fatal("expected error for uninitialized rotation, got nil")
+	}
+	if err != domain.ErrRotationNotInitialized {
+		t.Errorf("expected ErrRotationNotInitialized, got: %v", err)
+	}
+}
+
+func TestRotationUseCase_Skip_AdvancesPosition(t *testing.T) {
+	repo := newMockRotationRepo()
+	_ = repo.SetOrder([]string{"user-1", "user-2", "user-3"})
+	uc := usecase.NewRotationUseCase(repo, newMockUserRepoForRotation("user-1", "user-2", "user-3"))
+
+	if err := uc.Skip(); err != nil {
+		t.Fatalf("expected no error on first skip, got: %v", err)
+	}
+	if repo.rotation.CurrentPos != 1 {
+		t.Errorf("expected pos 1 after first skip, got %d", repo.rotation.CurrentPos)
+	}
+}
+
+func TestRotationUseCase_Skip_WrapsAround(t *testing.T) {
+	repo := newMockRotationRepo()
+	_ = repo.SetOrder([]string{"user-1", "user-2"})
+	repo.rotation.CurrentPos = 1 // already at last position
+	uc := usecase.NewRotationUseCase(repo, newMockUserRepoForRotation("user-1", "user-2"))
+
+	if err := uc.Skip(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if repo.rotation.CurrentPos != 0 {
+		t.Errorf("expected pos 0 after wrap, got %d", repo.rotation.CurrentPos)
+	}
+}

--- a/internal/usecase/user_test.go
+++ b/internal/usecase/user_test.go
@@ -40,6 +40,23 @@ func (m *mockRepo) FindByProviderID(provider, providerID string) (*domain.User, 
 	return nil, nil
 }
 
+func (m *mockRepo) FindByID(id string) (*domain.User, error) {
+	for _, u := range m.users {
+		if u.ID == id {
+			return u, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockRepo) FindAll() ([]*domain.User, error) {
+	users := make([]*domain.User, 0, len(m.users))
+	for _, u := range m.users {
+		users = append(users, u)
+	}
+	return users, nil
+}
+
 func TestCreateUser(t *testing.T) {
 	repo := newMockRepo()
 	uc := usecase.NewUserUseCase(repo, "test-jwt-secret")

--- a/migrations/000003_create_rotation_tables.down.sql
+++ b/migrations/000003_create_rotation_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS rotation_members;
+DROP TABLE IF EXISTS rotations;

--- a/migrations/000003_create_rotation_tables.up.sql
+++ b/migrations/000003_create_rotation_tables.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS rotations (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    current_pos INT         NOT NULL DEFAULT 0,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS rotation_members (
+    rotation_id UUID NOT NULL REFERENCES rotations(id) ON DELETE CASCADE,
+    user_id     UUID NOT NULL REFERENCES users(id)     ON DELETE CASCADE,
+    position    INT  NOT NULL,
+    UNIQUE (rotation_id, user_id),
+    UNIQUE (rotation_id, position)
+);


### PR DESCRIPTION
Description:
  Closes #3

  ## O que foi feito
  - Migration 000003: tabelas `rotations` (singleton) e `rotation_members` (fila ordenada)
  - Domain `Rotation` com `CurrentPayerID()`, interface `RotationRepository`
  - Extensão de `UserRepository` com `FindByID` e `FindAll`
  - `RotationUseCase` com validação (empty/duplicates/unknown user)
  - `RotationRepository` Postgres com transações
  - `GET /v1/rotation` — qualquer usuário autenticado
  - `PUT /v1/rotation/order` — admin only
  - `POST /v1/rotation/skip` — admin only
  - Swagger atualizado

  ## Test Plan
  - [x] `go test ./...` — todos os testes passam
  - [x] `GET /v1/rotation` retorna fila vazia inicialmente
  - [x] `PUT /v1/rotation/order` com array de user_ids válidos define a ordem
  - [x] `POST /v1/rotation/skip` avança a posição circular
  - [x] `PUT /v1/rotation/order` com user_id inválido retorna 400
  - [x] `PUT /v1/rotation/order` com duplicatas retorna 400
  - [x] `POST /v1/rotation/skip` sem rotation inicializada retorna 409