### PR TITLE
feat: round - rodada diária de pão de queijo

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -42,6 +42,11 @@ func (app *application) mount() http.Handler {
 			r.Get("/rotation", app.rotationHandler.GetCurrent)
 			r.With(handler.AdminOnly).Put("/rotation/order", app.rotationHandler.UpdateOrder)
 			r.With(handler.AdminOnly).Post("/rotation/skip", app.rotationHandler.Skip)
+
+			r.Get("/rounds", app.roundHandler.GetAll)
+			r.Get("/rounds/today", app.roundHandler.GetToday)
+			r.Post("/rounds/{id}/confirm", app.roundHandler.Confirm)
+			r.Post("/rounds/{id}/cancel", app.roundHandler.Cancel)
 		})
 	})
 
@@ -71,6 +76,7 @@ type application struct {
 	authHandler     *handler.AuthHandler
 	configHandler   *handler.ConfigHandler
 	rotationHandler *handler.RotationHandler
+	roundHandler    *handler.RoundHandler
 }
 
 type config struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 
+	"github.com/robfig/cron/v3"
 	"github.com/antoniobt12062002/pao-de-queijo/internal/db"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
 	handler "github.com/antoniobt12062002/pao-de-queijo/internal/handler/http"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/job"
 	"github.com/antoniobt12062002/pao-de-queijo/internal/repository/postgres"
 	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
 	"github.com/joho/godotenv"
@@ -62,6 +67,42 @@ func main() {
 	rotationUC      := usecase.NewRotationUseCase(rotationRepo, userRepo)
 	rotationHandler := handler.NewRotationHandler(rotationUC)
 
+	roundRepo    := postgres.NewRoundRepository(gormDB)
+	noopNotify   := &domain.NoopNotificationService{}
+	noopScore    := &domain.NoopScoreUpdater{}
+	roundUC      := usecase.NewRoundUseCase(roundRepo, rotationRepo, noopNotify)
+	roundHandler := handler.NewRoundHandler(roundUC)
+
+	// Background jobs
+	closer  := job.NewParticipationWindowCloser(roundRepo, noopNotify, noopScore)
+	reminder := job.NewReminderSender(roundRepo, noopNotify)
+	creator  := job.NewDailyRoundCreator(roundRepo, rotationRepo, configRepo, noopNotify, closer, reminder)
+
+	// Scheduler: lê notify_at da config para montar expressão cron
+	notifyAt := "08:00"
+	if configs, err := configRepo.GetAll(); err == nil {
+		for _, c := range configs {
+			if c.Key == "notify_at" {
+				notifyAt = c.Value
+			}
+		}
+	}
+	parts := strings.Split(notifyAt, ":")
+	hour, minute := "8", "0"
+	if len(parts) == 2 {
+		hour = strconv.Itoa(mustAtoi(parts[0]))
+		minute = strconv.Itoa(mustAtoi(parts[1]))
+	}
+	cronExpr := "0 " + minute + " " + hour + " * * *"
+
+	c := cron.New(cron.WithSeconds())
+	if _, err := c.AddFunc(cronExpr, creator.Run); err != nil {
+		slog.Error("failed to schedule DailyRoundCreator", "err", err)
+		os.Exit(1)
+	}
+	c.Start()
+	slog.Info("cron scheduler started", "DailyRoundCreator", cronExpr)
+
 	cfg := &config{
 		addr:      ":8080",
 		db:        dbConfig{dsn: dsn},
@@ -74,10 +115,19 @@ func main() {
 		authHandler:     authHandler,
 		configHandler:   configHandler,
 		rotationHandler: rotationHandler,
+		roundHandler:    roundHandler,
 	}
 
 	if err := api.run(api.mount()); err != nil {
 		slog.Error("error starting server", "err", err)
 		os.Exit(1)
 	}
+}
+
+func mustAtoi(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -366,6 +366,204 @@ const docTemplate = `{
                 }
             }
         },
+        "/rounds": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna histórico paginado de rodadas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Listar rodadas",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Página (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Itens por página (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.PaginatedRoundsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/today": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a rodada do dia atual com campo is_payer para o usuário autenticado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Rodada de hoje",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.TodayRoundResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/{id}/cancel": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pagador cancela a rodada; próximo da fila é notificado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Cancelar pagamento",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Round ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "payer only",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "round not in pending status",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/{id}/confirm": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pagador confirma a rodada, abrindo para participações",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Confirmar pagamento",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Round ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "payer only",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "round not in pending status",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "description": "Cria um novo usuário com email e senha",
@@ -441,6 +639,48 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "domain.Round": {
+            "type": "object",
+            "properties": {
+                "closes_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date": {
+                    "description": "\"YYYY-MM-DD\"",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "notify_at": {
+                    "type": "string"
+                },
+                "payer_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.RoundStatus"
+                }
+            }
+        },
+        "domain.RoundStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "open",
+                "closed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "RoundStatusPending",
+                "RoundStatusOpen",
+                "RoundStatusClosed",
+                "RoundStatusCancelled"
+            ]
         },
         "domain.User": {
             "type": "object",
@@ -607,6 +847,26 @@ const docTemplate = `{
                 }
             }
         },
+        "usecase.PaginatedRoundsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Round"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "usecase.RotationResponse": {
             "type": "object",
             "properties": {
@@ -621,6 +881,36 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.RotationMember"
                     }
+                }
+            }
+        },
+        "usecase.TodayRoundResponse": {
+            "type": "object",
+            "properties": {
+                "closes_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date": {
+                    "description": "\"YYYY-MM-DD\"",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_payer": {
+                    "type": "boolean"
+                },
+                "notify_at": {
+                    "type": "string"
+                },
+                "payer_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.RoundStatus"
                 }
             }
         }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -360,6 +360,204 @@
                 }
             }
         },
+        "/rounds": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna histórico paginado de rodadas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Listar rodadas",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Página (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Itens por página (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.PaginatedRoundsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/today": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a rodada do dia atual com campo is_payer para o usuário autenticado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Rodada de hoje",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/usecase.TodayRoundResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/{id}/cancel": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pagador cancela a rodada; próximo da fila é notificado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Cancelar pagamento",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Round ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "payer only",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "round not in pending status",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
+        "/rounds/{id}/confirm": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pagador confirma a rodada, abrindo para participações",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rounds"
+                ],
+                "summary": "Confirmar pagamento",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Round ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrInvalidCredentials"
+                        }
+                    },
+                    "403": {
+                        "description": "payer only",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    },
+                    "409": {
+                        "description": "round not in pending status",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrValidation"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "description": "Cria um novo usuário com email e senha",
@@ -435,6 +633,48 @@
                     "type": "string"
                 }
             }
+        },
+        "domain.Round": {
+            "type": "object",
+            "properties": {
+                "closes_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date": {
+                    "description": "\"YYYY-MM-DD\"",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "notify_at": {
+                    "type": "string"
+                },
+                "payer_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.RoundStatus"
+                }
+            }
+        },
+        "domain.RoundStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "open",
+                "closed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "RoundStatusPending",
+                "RoundStatusOpen",
+                "RoundStatusClosed",
+                "RoundStatusCancelled"
+            ]
         },
         "domain.User": {
             "type": "object",
@@ -601,6 +841,26 @@
                 }
             }
         },
+        "usecase.PaginatedRoundsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Round"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "usecase.RotationResponse": {
             "type": "object",
             "properties": {
@@ -615,6 +875,36 @@
                     "items": {
                         "$ref": "#/definitions/domain.RotationMember"
                     }
+                }
+            }
+        },
+        "usecase.TodayRoundResponse": {
+            "type": "object",
+            "properties": {
+                "closes_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date": {
+                    "description": "\"YYYY-MM-DD\"",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_payer": {
+                    "type": "boolean"
+                },
+                "notify_at": {
+                    "type": "string"
+                },
+                "payer_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.RoundStatus"
                 }
             }
         }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -14,6 +14,36 @@ definitions:
       user_id:
         type: string
     type: object
+  domain.Round:
+    properties:
+      closes_at:
+        type: string
+      created_at:
+        type: string
+      date:
+        description: '"YYYY-MM-DD"'
+        type: string
+      id:
+        type: string
+      notify_at:
+        type: string
+      payer_id:
+        type: string
+      status:
+        $ref: '#/definitions/domain.RoundStatus'
+    type: object
+  domain.RoundStatus:
+    enum:
+    - pending
+    - open
+    - closed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - RoundStatusPending
+    - RoundStatusOpen
+    - RoundStatusClosed
+    - RoundStatusCancelled
   domain.User:
     properties:
       created_at:
@@ -123,6 +153,19 @@ definitions:
           type: string
         type: array
     type: object
+  usecase.PaginatedRoundsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/domain.Round'
+        type: array
+      limit:
+        type: integer
+      page:
+        type: integer
+      total:
+        type: integer
+    type: object
   usecase.RotationResponse:
     properties:
       current_payer_id:
@@ -133,6 +176,26 @@ definitions:
         items:
           $ref: '#/definitions/domain.RotationMember'
         type: array
+    type: object
+  usecase.TodayRoundResponse:
+    properties:
+      closes_at:
+        type: string
+      created_at:
+        type: string
+      date:
+        description: '"YYYY-MM-DD"'
+        type: string
+      id:
+        type: string
+      is_payer:
+        type: boolean
+      notify_at:
+        type: string
+      payer_id:
+        type: string
+      status:
+        $ref: '#/definitions/domain.RoundStatus'
     type: object
 host: localhost:8080
 info:
@@ -366,6 +429,132 @@ paths:
       summary: Pular vez no rodízio
       tags:
       - rotation
+  /rounds:
+    get:
+      description: Retorna histórico paginado de rodadas
+      parameters:
+      - description: Página (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Itens por página (default 20, max 100)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/usecase.PaginatedRoundsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+      security:
+      - BearerAuth: []
+      summary: Listar rodadas
+      tags:
+      - rounds
+  /rounds/{id}/cancel:
+    post:
+      description: Pagador cancela a rodada; próximo da fila é notificado
+      parameters:
+      - description: Round ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+        "403":
+          description: payer only
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "409":
+          description: round not in pending status
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+      security:
+      - BearerAuth: []
+      summary: Cancelar pagamento
+      tags:
+      - rounds
+  /rounds/{id}/confirm:
+    post:
+      description: Pagador confirma a rodada, abrindo para participações
+      parameters:
+      - description: Round ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+        "403":
+          description: payer only
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+        "409":
+          description: round not in pending status
+          schema:
+            $ref: '#/definitions/http.ErrValidation'
+      security:
+      - BearerAuth: []
+      summary: Confirmar pagamento
+      tags:
+      - rounds
+  /rounds/today:
+    get:
+      description: Retorna a rodada do dia atual com campo is_payer para o usuário
+        autenticado
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/usecase.TodayRoundResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrInvalidCredentials'
+      security:
+      - BearerAuth: []
+      summary: Rodada de hoje
+      tags:
+      - rounds
   /users:
     post:
       consumes:

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/swaggo/files v0.0.0-20220610200504-28940afbdbfe // indirect
 	golang.org/x/mod v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -1,0 +1,16 @@
+package domain
+
+// NotificationService envia notificações aos usuários.
+// Implementação real será feita em feature/notification.
+type NotificationService interface {
+	SendRoundAnnounced(payerID string) error
+	SendRoundClosed(payerID string) error
+	SendReminder(participantIDs []string) error
+}
+
+// NoopNotificationService é a implementação stub usada até feature/notification.
+type NoopNotificationService struct{}
+
+func (n *NoopNotificationService) SendRoundAnnounced(payerID string) error    { return nil }
+func (n *NoopNotificationService) SendRoundClosed(payerID string) error       { return nil }
+func (n *NoopNotificationService) SendReminder(participantIDs []string) error { return nil }

--- a/internal/domain/round.go
+++ b/internal/domain/round.go
@@ -1,0 +1,40 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrRoundNotFound   = errors.New("round not found")
+	ErrRoundNotPending = errors.New("round is not in pending status")
+	ErrRoundNotPayer   = errors.New("only the current payer can perform this action")
+	ErrRotationEmpty   = errors.New("rotation has no members configured")
+)
+
+type RoundStatus string
+
+const (
+	RoundStatusPending   RoundStatus = "pending"
+	RoundStatusOpen      RoundStatus = "open"
+	RoundStatusClosed    RoundStatus = "closed"
+	RoundStatusCancelled RoundStatus = "cancelled"
+)
+
+type Round struct {
+	ID        string      `json:"id"`
+	Date      string      `json:"date"` // "YYYY-MM-DD"
+	PayerID   string      `json:"payer_id"`
+	Status    RoundStatus `json:"status"`
+	NotifyAt  time.Time   `json:"notify_at"`
+	ClosesAt  time.Time   `json:"closes_at"`
+	CreatedAt time.Time   `json:"created_at"`
+}
+
+type RoundRepository interface {
+	Create(round *Round) error
+	GetByDate(date string) (*Round, error)
+	GetByID(id string) (*Round, error)
+	GetAll(page, limit int) ([]*Round, int64, error)
+	Update(round *Round) error
+}

--- a/internal/domain/score.go
+++ b/internal/domain/score.go
@@ -1,0 +1,12 @@
+package domain
+
+// ScoreUpdater atualiza o score dos usuários após o fechamento de uma rodada.
+// Implementação real será feita em feature/score-badges.
+type ScoreUpdater interface {
+	UpdateAfterRound(roundID string) error
+}
+
+// NoopScoreUpdater é a implementação stub usada até feature/score-badges.
+type NoopScoreUpdater struct{}
+
+func (n *NoopScoreUpdater) UpdateAfterRound(roundID string) error { return nil }

--- a/internal/handler/http/middleware.go
+++ b/internal/handler/http/middleware.go
@@ -15,6 +15,9 @@ const (
 	contextKeyRole   contextKey = "role"
 )
 
+// ContextKeyUserID é exportado para uso em testes de outros pacotes.
+const ContextKeyUserID = contextKeyUserID
+
 // JWTMiddleware valida o token Bearer e injeta user_id e role no contexto.
 // Retorna 401 se o token estiver ausente ou inválido.
 func JWTMiddleware(secret string) func(http.Handler) http.Handler {

--- a/internal/handler/http/round.go
+++ b/internal/handler/http/round.go
@@ -1,0 +1,144 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+type RoundHandler struct {
+	uc *usecase.RoundUseCase
+}
+
+func NewRoundHandler(uc *usecase.RoundUseCase) *RoundHandler {
+	return &RoundHandler{uc: uc}
+}
+
+// GetAll godoc
+// @Summary      Listar rodadas
+// @Description  Retorna histórico paginado de rodadas
+// @Tags         rounds
+// @Produce      json
+// @Security     BearerAuth
+// @Param        page   query     int  false  "Página (default 1)"
+// @Param        limit  query     int  false  "Itens por página (default 20, max 100)"
+// @Success      200    {object}  usecase.PaginatedRoundsResponse
+// @Failure      401    {object}  ErrInvalidCredentials
+// @Router       /rounds [get]
+func (h *RoundHandler) GetAll(w http.ResponseWriter, r *http.Request) {
+	page := parseIntParam(r.URL.Query().Get("page"), 1)
+	limit := parseIntParam(r.URL.Query().Get("limit"), 20)
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+
+	resp, err := h.uc.GetAll(page, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// GetToday godoc
+// @Summary      Rodada de hoje
+// @Description  Retorna a rodada do dia atual com campo is_payer para o usuário autenticado
+// @Tags         rounds
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  usecase.TodayRoundResponse
+// @Failure      401  {object}  ErrInvalidCredentials
+// @Router       /rounds/today [get]
+func (h *RoundHandler) GetToday(w http.ResponseWriter, r *http.Request) {
+	userID := UserIDFromContext(r.Context())
+	resp, err := h.uc.GetToday(userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Confirm godoc
+// @Summary      Confirmar pagamento
+// @Description  Pagador confirma a rodada, abrindo para participações
+// @Tags         rounds
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id   path      string  true  "Round ID"
+// @Success      200  {object}  map[string]string
+// @Failure      401  {object}  ErrInvalidCredentials
+// @Failure      403  {object}  ErrValidation  "payer only"
+// @Failure      404  {object}  ErrValidation
+// @Failure      409  {object}  ErrValidation  "round not in pending status"
+// @Router       /rounds/{id}/confirm [post]
+func (h *RoundHandler) Confirm(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userID := UserIDFromContext(r.Context())
+
+	if err := h.uc.Confirm(id, userID); err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRoundNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, domain.ErrRoundNotPayer):
+			writeError(w, http.StatusForbidden, err.Error())
+		case errors.Is(err, domain.ErrRoundNotPending):
+			writeError(w, http.StatusConflict, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"message": "round confirmed"})
+}
+
+// Cancel godoc
+// @Summary      Cancelar pagamento
+// @Description  Pagador cancela a rodada; próximo da fila é notificado
+// @Tags         rounds
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id   path      string  true  "Round ID"
+// @Success      200  {object}  map[string]string
+// @Failure      401  {object}  ErrInvalidCredentials
+// @Failure      403  {object}  ErrValidation  "payer only"
+// @Failure      404  {object}  ErrValidation
+// @Failure      409  {object}  ErrValidation  "round not in pending status"
+// @Router       /rounds/{id}/cancel [post]
+func (h *RoundHandler) Cancel(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	userID := UserIDFromContext(r.Context())
+
+	if err := h.uc.Cancel(id, userID); err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRoundNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, domain.ErrRoundNotPayer):
+			writeError(w, http.StatusForbidden, err.Error())
+		case errors.Is(err, domain.ErrRoundNotPending):
+			writeError(w, http.StatusConflict, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal server error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"message": "round cancelled and reassigned"})
+}
+
+func parseIntParam(s string, defaultVal int) int {
+	if s == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}

--- a/internal/handler/http/round_test.go
+++ b/internal/handler/http/round_test.go
@@ -1,0 +1,261 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	handler "github.com/antoniobt12062002/pao-de-queijo/internal/handler/http"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+// --- stubs ---
+
+type stubRoundRepo struct {
+	rounds map[string]*domain.Round
+	byDate map[string]*domain.Round
+}
+
+func newStubRoundRepo() *stubRoundRepo {
+	return &stubRoundRepo{
+		rounds: make(map[string]*domain.Round),
+		byDate: make(map[string]*domain.Round),
+	}
+}
+
+func (s *stubRoundRepo) Create(r *domain.Round) error {
+	r.ID = "round-stub-1"
+	s.rounds[r.ID] = r
+	s.byDate[r.Date] = r
+	return nil
+}
+
+func (s *stubRoundRepo) GetByDate(date string) (*domain.Round, error) {
+	return s.byDate[date], nil
+}
+
+func (s *stubRoundRepo) GetByID(id string) (*domain.Round, error) {
+	return s.rounds[id], nil
+}
+
+func (s *stubRoundRepo) GetAll(page, limit int) ([]*domain.Round, int64, error) {
+	rounds := make([]*domain.Round, 0, len(s.rounds))
+	for _, r := range s.rounds {
+		rounds = append(rounds, r)
+	}
+	return rounds, int64(len(rounds)), nil
+}
+
+func (s *stubRoundRepo) Update(r *domain.Round) error {
+	s.rounds[r.ID] = r
+	s.byDate[r.Date] = r
+	return nil
+}
+
+type stubRotationRepoForRound struct {
+	rotation *domain.Rotation
+}
+
+func newStubRotationRepoForRound(members ...*domain.RotationMember) *stubRotationRepoForRound {
+	var rot *domain.Rotation
+	if len(members) > 0 {
+		rot = &domain.Rotation{ID: "rot-1", CurrentPos: 0, Members: members}
+	}
+	return &stubRotationRepoForRound{rotation: rot}
+}
+
+func (s *stubRotationRepoForRound) Get() (*domain.Rotation, error) { return s.rotation, nil }
+func (s *stubRotationRepoForRound) SetOrder(ids []string) error     { return nil }
+func (s *stubRotationRepoForRound) AdvancePosition() error {
+	if s.rotation != nil && len(s.rotation.Members) > 0 {
+		s.rotation.CurrentPos = (s.rotation.CurrentPos + 1) % len(s.rotation.Members)
+	}
+	return nil
+}
+
+type stubNotifySvcForRound struct{}
+
+func (s *stubNotifySvcForRound) SendRoundAnnounced(id string) error    { return nil }
+func (s *stubNotifySvcForRound) SendRoundClosed(id string) error       { return nil }
+func (s *stubNotifySvcForRound) SendReminder(ids []string) error        { return nil }
+
+// withUserID injects user_id into context to simulate JWTMiddleware
+func withUserID(r *http.Request, userID string) *http.Request {
+	ctx := context.WithValue(r.Context(), handler.ContextKeyUserID, userID)
+	return r.WithContext(ctx)
+}
+
+// --- tests ---
+
+func TestRoundHandler_GetAll_Empty(t *testing.T) {
+	uc := usecase.NewRoundUseCase(newStubRoundRepo(), newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rounds", nil)
+	w := httptest.NewRecorder()
+	h.GetAll(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	data, _ := resp["data"].([]any)
+	if len(data) != 0 {
+		t.Errorf("expected empty data, got %d", len(data))
+	}
+}
+
+func TestRoundHandler_GetToday_NoRound(t *testing.T) {
+	uc := usecase.NewRoundUseCase(newStubRoundRepo(), newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rounds/today", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+	h.GetToday(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRoundHandler_GetToday_WithRound(t *testing.T) {
+	repo := newStubRoundRepo()
+	today := time.Now().Format("2006-01-02")
+	round := &domain.Round{ID: "r1", Date: today, PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["r1"] = round
+	repo.byDate[today] = round
+
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/rounds/today", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+	h.GetToday(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["is_payer"] != true {
+		t.Errorf("expected is_payer=true, got: %v", resp["is_payer"])
+	}
+}
+
+func TestRoundHandler_Confirm_Valid(t *testing.T) {
+	repo := newStubRoundRepo()
+	round := &domain.Round{ID: "r1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["r1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	r := chi.NewRouter()
+	r.Post("/rounds/{id}/confirm", h.Confirm)
+
+	req := httptest.NewRequest(http.MethodPost, "/rounds/r1/confirm", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRoundHandler_Confirm_NotPending(t *testing.T) {
+	repo := newStubRoundRepo()
+	round := &domain.Round{ID: "r1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusOpen}
+	repo.rounds["r1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	r := chi.NewRouter()
+	r.Post("/rounds/{id}/confirm", h.Confirm)
+
+	req := httptest.NewRequest(http.MethodPost, "/rounds/r1/confirm", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestRoundHandler_Confirm_NotPayer(t *testing.T) {
+	repo := newStubRoundRepo()
+	round := &domain.Round{ID: "r1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["r1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	r := chi.NewRouter()
+	r.Post("/rounds/{id}/confirm", h.Confirm)
+
+	req := httptest.NewRequest(http.MethodPost, "/rounds/r1/confirm", nil)
+	req = withUserID(req, "user-2")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRoundHandler_Cancel_Valid(t *testing.T) {
+	repo := newStubRoundRepo()
+	round := &domain.Round{ID: "r1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["r1"] = round
+	repo.byDate["2026-01-01"] = round
+
+	members := []*domain.RotationMember{
+		{UserID: "user-1", Position: 0},
+		{UserID: "user-2", Position: 1},
+	}
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(members...), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	r := chi.NewRouter()
+	r.Post("/rounds/{id}/cancel", h.Cancel)
+
+	req := httptest.NewRequest(http.MethodPost, "/rounds/r1/cancel", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRoundHandler_Cancel_NotPayer(t *testing.T) {
+	repo := newStubRoundRepo()
+	round := &domain.Round{ID: "r1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["r1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newStubRotationRepoForRound(), &stubNotifySvcForRound{})
+	h := handler.NewRoundHandler(uc)
+
+	r := chi.NewRouter()
+	r.Post("/rounds/{id}/cancel", h.Cancel)
+
+	req := httptest.NewRequest(http.MethodPost, "/rounds/r1/cancel", nil)
+	req = withUserID(req, "user-2")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}

--- a/internal/job/round_closer.go
+++ b/internal/job/round_closer.go
@@ -1,0 +1,96 @@
+package job
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+)
+
+// ParticipationWindowCloser fecha a rodada do dia após o período de participação.
+type ParticipationWindowCloser struct {
+	roundRepo    domain.RoundRepository
+	notifySvc    domain.NotificationService
+	scoreUpdater domain.ScoreUpdater
+}
+
+func NewParticipationWindowCloser(
+	roundRepo domain.RoundRepository,
+	notifySvc domain.NotificationService,
+	scoreUpdater domain.ScoreUpdater,
+) *ParticipationWindowCloser {
+	return &ParticipationWindowCloser{
+		roundRepo:    roundRepo,
+		notifySvc:    notifySvc,
+		scoreUpdater: scoreUpdater,
+	}
+}
+
+// Run fecha a rodada de hoje se estiver aberta.
+func (j *ParticipationWindowCloser) Run() {
+	today := time.Now().Format("2006-01-02")
+	round, err := j.roundRepo.GetByDate(today)
+	if err != nil {
+		slog.Error("ParticipationWindowCloser: error fetching round", "err", err)
+		return
+	}
+	if round == nil {
+		slog.Warn("ParticipationWindowCloser: no round found for today")
+		return
+	}
+	if round.Status != domain.RoundStatusOpen {
+		slog.Info("ParticipationWindowCloser: round is not open, skipping", "status", round.Status)
+		return
+	}
+
+	round.Status = domain.RoundStatusClosed
+	if err := j.roundRepo.Update(round); err != nil {
+		slog.Error("ParticipationWindowCloser: error closing round", "err", err)
+		return
+	}
+
+	slog.Info("ParticipationWindowCloser: round closed", "id", round.ID)
+
+	// Notifica o pagador (noop por enquanto)
+	if err := j.notifySvc.SendRoundClosed(round.PayerID); err != nil {
+		slog.Error("ParticipationWindowCloser: error sending notification", "err", err)
+	}
+
+	// Atualiza score (noop por enquanto)
+	if err := j.scoreUpdater.UpdateAfterRound(round.ID); err != nil {
+		slog.Error("ParticipationWindowCloser: error updating score", "err", err)
+	}
+}
+
+// ReminderSender envia lembretes aos participantes antes do fechamento.
+type ReminderSender struct {
+	roundRepo domain.RoundRepository
+	notifySvc domain.NotificationService
+}
+
+func NewReminderSender(
+	roundRepo domain.RoundRepository,
+	notifySvc domain.NotificationService,
+) *ReminderSender {
+	return &ReminderSender{
+		roundRepo: roundRepo,
+		notifySvc: notifySvc,
+	}
+}
+
+// Run envia lembrete se a rodada estiver aberta e tiver ao menos 1 participante.
+// Como feature/participation ainda não foi implementada, este job é um stub.
+func (j *ReminderSender) Run() {
+	today := time.Now().Format("2006-01-02")
+	round, err := j.roundRepo.GetByDate(today)
+	if err != nil {
+		slog.Error("ReminderSender: error fetching round", "err", err)
+		return
+	}
+	if round == nil || round.Status != domain.RoundStatusOpen {
+		slog.Info("ReminderSender: round not open, skipping reminder")
+		return
+	}
+	// TODO: buscar participantes quando feature/participation for implementada
+	slog.Info("ReminderSender: participation data not available yet, skipping reminder", "round_id", round.ID)
+}

--- a/internal/job/round_creator.go
+++ b/internal/job/round_creator.go
@@ -1,0 +1,117 @@
+package job
+
+import (
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+)
+
+// DailyRoundCreator cria a rodada do dia e agenda os jobs dinâmicos.
+type DailyRoundCreator struct {
+	roundRepo    domain.RoundRepository
+	rotationRepo domain.RotationRepository
+	configRepo   domain.ConfigRepository
+	notifySvc    domain.NotificationService
+	closer       *ParticipationWindowCloser
+	reminder     *ReminderSender
+}
+
+func NewDailyRoundCreator(
+	roundRepo domain.RoundRepository,
+	rotationRepo domain.RotationRepository,
+	configRepo domain.ConfigRepository,
+	notifySvc domain.NotificationService,
+	closer *ParticipationWindowCloser,
+	reminder *ReminderSender,
+) *DailyRoundCreator {
+	return &DailyRoundCreator{
+		roundRepo:    roundRepo,
+		rotationRepo: rotationRepo,
+		configRepo:   configRepo,
+		notifySvc:    notifySvc,
+		closer:       closer,
+		reminder:     reminder,
+	}
+}
+
+// Run executa o job de criação diária de rodada. É idempotente.
+func (j *DailyRoundCreator) Run() {
+	today := time.Now().Format("2006-01-02")
+
+	// Idempotência: verifica se já existe rodada para hoje
+	existing, err := j.roundRepo.GetByDate(today)
+	if err != nil {
+		slog.Error("DailyRoundCreator: error checking existing round", "err", err)
+		return
+	}
+	if existing != nil {
+		slog.Info("DailyRoundCreator: round already exists for today, skipping", "date", today)
+		return
+	}
+
+	// Lê configuração
+	configs, err := j.configRepo.GetAll()
+	if err != nil {
+		slog.Error("DailyRoundCreator: error reading config", "err", err)
+		return
+	}
+	configMap := make(map[string]string)
+	for _, c := range configs {
+		configMap[c.Key] = c.Value
+	}
+
+	windowMinutes := 30
+	if v, ok := configMap["round_window_minutes"]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			windowMinutes = n
+		}
+	}
+
+	// Obtém pagador atual do rodízio
+	rotation, err := j.rotationRepo.Get()
+	if err != nil || rotation == nil || len(rotation.Members) == 0 {
+		slog.Warn("DailyRoundCreator: no rotation configured, skipping round creation")
+		return
+	}
+
+	payerID := rotation.CurrentPayerID()
+	now := time.Now()
+	closesAt := now.Add(time.Duration(windowMinutes) * time.Minute)
+	reminderAt := closesAt.Add(-5 * time.Minute)
+
+	// Cria a rodada
+	round := &domain.Round{
+		Date:     today,
+		PayerID:  payerID,
+		Status:   domain.RoundStatusPending,
+		NotifyAt: now,
+		ClosesAt: closesAt,
+	}
+	if err := j.roundRepo.Create(round); err != nil {
+		slog.Error("DailyRoundCreator: error creating round", "err", err)
+		return
+	}
+
+	slog.Info("DailyRoundCreator: round created", "id", round.ID, "payer", payerID)
+
+	// Agenda ParticipationWindowCloser dinamicamente (one-shot)
+	durationToClose := time.Until(closesAt)
+	if durationToClose > 0 {
+		time.AfterFunc(durationToClose, j.closer.Run)
+		slog.Info("DailyRoundCreator: ParticipationWindowCloser scheduled", "at", closesAt)
+	}
+
+	// Agenda ReminderSender dinamicamente (one-shot, 5 min antes do fechamento)
+	durationToRemind := time.Until(reminderAt)
+	if durationToRemind > 0 {
+		time.AfterFunc(durationToRemind, j.reminder.Run)
+		slog.Info("DailyRoundCreator: ReminderSender scheduled", "at", reminderAt)
+	}
+
+	// Notifica o pagador (noop por enquanto)
+	if err := j.notifySvc.SendRoundAnnounced(payerID); err != nil {
+		slog.Error("DailyRoundCreator: error sending notification", "err", err)
+	}
+}

--- a/internal/repository/postgres/round.go
+++ b/internal/repository/postgres/round.go
@@ -1,0 +1,113 @@
+package postgres
+
+import (
+	"errors"
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"gorm.io/gorm"
+)
+
+type roundModel struct {
+	ID        string    `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+	Date      string    `gorm:"column:date;type:date"`
+	PayerID   string    `gorm:"column:payer_id;type:uuid"`
+	Status    string    `gorm:"column:status"`
+	NotifyAt  time.Time `gorm:"column:notify_at"`
+	ClosesAt  time.Time `gorm:"column:closes_at"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (roundModel) TableName() string { return "rounds" }
+
+type RoundRepository struct {
+	db *gorm.DB
+}
+
+func NewRoundRepository(db *gorm.DB) *RoundRepository {
+	return &RoundRepository{db: db}
+}
+
+func (r *RoundRepository) Create(round *domain.Round) error {
+	m := toRoundModel(round)
+	if err := r.db.Create(m).Error; err != nil {
+		return err
+	}
+	round.ID = m.ID
+	return nil
+}
+
+func (r *RoundRepository) GetByDate(date string) (*domain.Round, error) {
+	var m roundModel
+	result := r.db.Where("date = ?", date).First(&m)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return toDomainRound(&m), nil
+}
+
+func (r *RoundRepository) GetByID(id string) (*domain.Round, error) {
+	var m roundModel
+	result := r.db.Where("id = ?", id).First(&m)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return toDomainRound(&m), nil
+}
+
+func (r *RoundRepository) GetAll(page, limit int) ([]*domain.Round, int64, error) {
+	var models []roundModel
+	var total int64
+
+	if err := r.db.Model(&roundModel{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * limit
+	if err := r.db.Order("created_at DESC").Offset(offset).Limit(limit).Find(&models).Error; err != nil {
+		return nil, 0, err
+	}
+
+	rounds := make([]*domain.Round, len(models))
+	for i, m := range models {
+		rounds[i] = toDomainRound(&m)
+	}
+	return rounds, total, nil
+}
+
+func (r *RoundRepository) Update(round *domain.Round) error {
+	m := toRoundModel(round)
+	return r.db.Save(m).Error
+}
+
+func toRoundModel(r *domain.Round) *roundModel {
+	return &roundModel{
+		ID:       r.ID,
+		Date:     r.Date,
+		PayerID:  r.PayerID,
+		Status:   string(r.Status),
+		NotifyAt: r.NotifyAt,
+		ClosesAt: r.ClosesAt,
+	}
+}
+
+func toDomainRound(m *roundModel) *domain.Round {
+	return &domain.Round{
+		ID:        m.ID,
+		Date:      m.Date,
+		PayerID:   m.PayerID,
+		Status:    domain.RoundStatus(m.Status),
+		NotifyAt:  m.NotifyAt,
+		ClosesAt:  m.ClosesAt,
+		CreatedAt: m.CreatedAt,
+	}
+}
+
+// Verify interface compliance at compile time
+var _ domain.RoundRepository = (*RoundRepository)(nil)

--- a/internal/usecase/round.go
+++ b/internal/usecase/round.go
@@ -1,0 +1,125 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+)
+
+type RoundUseCase struct {
+	roundRepo    domain.RoundRepository
+	rotationRepo domain.RotationRepository
+	notifySvc    domain.NotificationService
+}
+
+func NewRoundUseCase(
+	roundRepo domain.RoundRepository,
+	rotationRepo domain.RotationRepository,
+	notifySvc domain.NotificationService,
+) *RoundUseCase {
+	return &RoundUseCase{
+		roundRepo:    roundRepo,
+		rotationRepo: rotationRepo,
+		notifySvc:    notifySvc,
+	}
+}
+
+// PaginatedRoundsResponse é a resposta paginada do GetAll.
+type PaginatedRoundsResponse struct {
+	Data  []*domain.Round `json:"data"`
+	Total int64           `json:"total"`
+	Page  int             `json:"page"`
+	Limit int             `json:"limit"`
+}
+
+// TodayRoundResponse é a resposta do GetToday, incluindo is_payer.
+type TodayRoundResponse struct {
+	*domain.Round
+	IsPayer bool `json:"is_payer"`
+}
+
+func (uc *RoundUseCase) GetAll(page, limit int) (*PaginatedRoundsResponse, error) {
+	rounds, total, err := uc.roundRepo.GetAll(page, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &PaginatedRoundsResponse{
+		Data:  rounds,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}, nil
+}
+
+func (uc *RoundUseCase) GetToday(callerID string) (*TodayRoundResponse, error) {
+	today := time.Now().Format("2006-01-02")
+	round, err := uc.roundRepo.GetByDate(today)
+	if err != nil {
+		return nil, err
+	}
+	if round == nil {
+		return nil, nil
+	}
+	return &TodayRoundResponse{
+		Round:   round,
+		IsPayer: round.PayerID == callerID,
+	}, nil
+}
+
+func (uc *RoundUseCase) Confirm(roundID, callerID string) error {
+	round, err := uc.roundRepo.GetByID(roundID)
+	if err != nil {
+		return err
+	}
+	if round == nil {
+		return domain.ErrRoundNotFound
+	}
+	if round.PayerID != callerID {
+		return domain.ErrRoundNotPayer
+	}
+	if round.Status != domain.RoundStatusPending {
+		return domain.ErrRoundNotPending
+	}
+	round.Status = domain.RoundStatusOpen
+	return uc.roundRepo.Update(round)
+}
+
+func (uc *RoundUseCase) Cancel(roundID, callerID string) error {
+	round, err := uc.roundRepo.GetByID(roundID)
+	if err != nil {
+		return err
+	}
+	if round == nil {
+		return domain.ErrRoundNotFound
+	}
+	if round.PayerID != callerID {
+		return domain.ErrRoundNotPayer
+	}
+	if round.Status != domain.RoundStatusPending {
+		return domain.ErrRoundNotPending
+	}
+
+	// Avança o rodízio para o próximo pagador
+	if err := uc.rotationRepo.AdvancePosition(); err != nil {
+		return err
+	}
+
+	rotation, err := uc.rotationRepo.Get()
+	if err != nil {
+		return err
+	}
+	if rotation == nil || len(rotation.Members) == 0 {
+		return domain.ErrRotationEmpty
+	}
+
+	// Reatribui o pagador (mantém mesma linha, evita conflito UNIQUE(date))
+	round.PayerID = rotation.CurrentPayerID()
+	round.Status = domain.RoundStatusPending
+	if err := uc.roundRepo.Update(round); err != nil {
+		return err
+	}
+
+	// Notifica o novo pagador (noop por enquanto)
+	_ = uc.notifySvc.SendRoundAnnounced(round.PayerID)
+	return nil
+}

--- a/internal/usecase/round_test.go
+++ b/internal/usecase/round_test.go
@@ -1,0 +1,261 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/antoniobt12062002/pao-de-queijo/internal/domain"
+	"github.com/antoniobt12062002/pao-de-queijo/internal/usecase"
+)
+
+// --- mocks ---
+
+type mockRoundRepo struct {
+	rounds map[string]*domain.Round
+	byDate map[string]*domain.Round
+}
+
+func newMockRoundRepo() *mockRoundRepo {
+	return &mockRoundRepo{
+		rounds: make(map[string]*domain.Round),
+		byDate: make(map[string]*domain.Round),
+	}
+}
+
+func (m *mockRoundRepo) Create(r *domain.Round) error {
+	r.ID = "round-uuid-1"
+	r.CreatedAt = time.Now()
+	m.rounds[r.ID] = r
+	m.byDate[r.Date] = r
+	return nil
+}
+
+func (m *mockRoundRepo) GetByDate(date string) (*domain.Round, error) {
+	return m.byDate[date], nil
+}
+
+func (m *mockRoundRepo) GetByID(id string) (*domain.Round, error) {
+	return m.rounds[id], nil
+}
+
+func (m *mockRoundRepo) GetAll(page, limit int) ([]*domain.Round, int64, error) {
+	rounds := make([]*domain.Round, 0, len(m.rounds))
+	for _, r := range m.rounds {
+		rounds = append(rounds, r)
+	}
+	return rounds, int64(len(rounds)), nil
+}
+
+func (m *mockRoundRepo) Update(r *domain.Round) error {
+	m.rounds[r.ID] = r
+	m.byDate[r.Date] = r
+	return nil
+}
+
+type mockRotationRepoForRound struct {
+	rotation *domain.Rotation
+}
+
+func newMockRotationRepoForRound(members ...*domain.RotationMember) *mockRotationRepoForRound {
+	var rotation *domain.Rotation
+	if len(members) > 0 {
+		rotation = &domain.Rotation{ID: "rot-1", CurrentPos: 0, Members: members}
+	}
+	return &mockRotationRepoForRound{rotation: rotation}
+}
+
+func (m *mockRotationRepoForRound) Get() (*domain.Rotation, error) {
+	return m.rotation, nil
+}
+
+func (m *mockRotationRepoForRound) SetOrder(userIDs []string) error { return nil }
+
+func (m *mockRotationRepoForRound) AdvancePosition() error {
+	if m.rotation == nil || len(m.rotation.Members) == 0 {
+		return domain.ErrRotationNotInitialized
+	}
+	m.rotation.CurrentPos = (m.rotation.CurrentPos + 1) % len(m.rotation.Members)
+	return nil
+}
+
+type mockNotifySvc struct{}
+
+func (n *mockNotifySvc) SendRoundAnnounced(payerID string) error    { return nil }
+func (n *mockNotifySvc) SendRoundClosed(payerID string) error       { return nil }
+func (n *mockNotifySvc) SendReminder(ids []string) error             { return nil }
+
+// --- tests ---
+
+func TestRoundUseCase_GetAll_Empty(t *testing.T) {
+	uc := usecase.NewRoundUseCase(newMockRoundRepo(), newMockRotationRepoForRound(), &mockNotifySvc{})
+	resp, err := uc.GetAll(1, 20)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(resp.Data) != 0 {
+		t.Errorf("expected empty data, got %d", len(resp.Data))
+	}
+	if resp.Total != 0 {
+		t.Errorf("expected total 0, got %d", resp.Total)
+	}
+}
+
+func TestRoundUseCase_GetToday_NoRound(t *testing.T) {
+	uc := usecase.NewRoundUseCase(newMockRoundRepo(), newMockRotationRepoForRound(), &mockNotifySvc{})
+	resp, err := uc.GetToday("user-1")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response when no round, got: %+v", resp)
+	}
+}
+
+func TestRoundUseCase_GetToday_IsPayer(t *testing.T) {
+	repo := newMockRoundRepo()
+	today := time.Now().Format("2006-01-02")
+	round := &domain.Round{
+		ID:      "round-1",
+		Date:    today,
+		PayerID: "user-1",
+		Status:  domain.RoundStatusPending,
+	}
+	repo.rounds["round-1"] = round
+	repo.byDate[today] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	resp, err := uc.GetToday("user-1")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected round, got nil")
+	}
+	if !resp.IsPayer {
+		t.Error("expected is_payer=true for the payer")
+	}
+}
+
+func TestRoundUseCase_GetToday_IsNotPayer(t *testing.T) {
+	repo := newMockRoundRepo()
+	today := time.Now().Format("2006-01-02")
+	round := &domain.Round{
+		ID:      "round-1",
+		Date:    today,
+		PayerID: "user-1",
+		Status:  domain.RoundStatusPending,
+	}
+	repo.rounds["round-1"] = round
+	repo.byDate[today] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	resp, err := uc.GetToday("user-2")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected round, got nil")
+	}
+	if resp.IsPayer {
+		t.Error("expected is_payer=false for a non-payer")
+	}
+}
+
+func TestRoundUseCase_Confirm_Valid(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["round-1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	if err := uc.Confirm("round-1", "user-1"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if repo.rounds["round-1"].Status != domain.RoundStatusOpen {
+		t.Errorf("expected status open, got %s", repo.rounds["round-1"].Status)
+	}
+}
+
+func TestRoundUseCase_Confirm_NotPending(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusOpen}
+	repo.rounds["round-1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	err := uc.Confirm("round-1", "user-1")
+	if err == nil {
+		t.Fatal("expected error for non-pending round, got nil")
+	}
+	if err != domain.ErrRoundNotPending {
+		t.Errorf("expected ErrRoundNotPending, got: %v", err)
+	}
+}
+
+func TestRoundUseCase_Confirm_NotPayer(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["round-1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	err := uc.Confirm("round-1", "user-2")
+	if err == nil {
+		t.Fatal("expected error for non-payer, got nil")
+	}
+	if err != domain.ErrRoundNotPayer {
+		t.Errorf("expected ErrRoundNotPayer, got: %v", err)
+	}
+}
+
+func TestRoundUseCase_Cancel_Valid(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["round-1"] = round
+	repo.byDate["2026-01-01"] = round
+
+	members := []*domain.RotationMember{
+		{UserID: "user-1", Position: 0},
+		{UserID: "user-2", Position: 1},
+	}
+	rotRepo := newMockRotationRepoForRound(members...)
+
+	uc := usecase.NewRoundUseCase(repo, rotRepo, &mockNotifySvc{})
+	if err := uc.Cancel("round-1", "user-1"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	updated := repo.rounds["round-1"]
+	if updated.PayerID != "user-2" {
+		t.Errorf("expected new payer to be user-2, got %s", updated.PayerID)
+	}
+	if updated.Status != domain.RoundStatusPending {
+		t.Errorf("expected status pending after reassignment, got %s", updated.Status)
+	}
+}
+
+func TestRoundUseCase_Cancel_NotPending(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusOpen}
+	repo.rounds["round-1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	err := uc.Cancel("round-1", "user-1")
+	if err == nil {
+		t.Fatal("expected error for non-pending round, got nil")
+	}
+	if err != domain.ErrRoundNotPending {
+		t.Errorf("expected ErrRoundNotPending, got: %v", err)
+	}
+}
+
+func TestRoundUseCase_Cancel_NotPayer(t *testing.T) {
+	repo := newMockRoundRepo()
+	round := &domain.Round{ID: "round-1", Date: "2026-01-01", PayerID: "user-1", Status: domain.RoundStatusPending}
+	repo.rounds["round-1"] = round
+
+	uc := usecase.NewRoundUseCase(repo, newMockRotationRepoForRound(), &mockNotifySvc{})
+	err := uc.Cancel("round-1", "user-2")
+	if err == nil {
+		t.Fatal("expected error for non-payer, got nil")
+	}
+	if err != domain.ErrRoundNotPayer {
+		t.Errorf("expected ErrRoundNotPayer, got: %v", err)
+	}
+}

--- a/migrations/000004_create_rounds_table.down.sql
+++ b/migrations/000004_create_rounds_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS rounds;

--- a/migrations/000004_create_rounds_table.up.sql
+++ b/migrations/000004_create_rounds_table.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS rounds (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    date        DATE        NOT NULL UNIQUE,
+    payer_id    UUID        NOT NULL REFERENCES users(id),
+    status      TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'open', 'closed', 'cancelled')),
+    notify_at   TIMESTAMPTZ NOT NULL,
+    closes_at   TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
 Closes #4

  ## O que foi feito
  - Migration 000004: tabela `rounds` com status enum e UNIQUE(date)
  - Domain `Round` com `RoundStatus`, `RoundRepository`, erros tipados
  - Interfaces stub: `NotificationService` e `ScoreUpdater` (implementadas em features futuras)
  - `RoundUseCase` com GetAll (paginado), GetToday (com is_payer), Confirm e Cancel
  - Cancel reatribui o pagador via rodízio sem criar nova linha (respeita UNIQUE(date))
  - `RoundRepository` Postgres com GORM
  - `GET /v1/rounds` — paginado, autenticado
  - `GET /v1/rounds/today` — autenticado, inclui is_payer
  - `POST /v1/rounds/:id/confirm` — payer only
  - `POST /v1/rounds/:id/cancel` — payer only
  - Jobs: DailyRoundCreator (cron fixo via robfig/cron), ParticipationWindowCloser e ReminderSender (time.AfterFunc one-shot)
  - Swagger atualizado

  ## Test Plan
  - [x] `go test ./...` — todos os testes passam
  - [x] `GET /v1/rounds` retorna lista vazia inicialmente
  - [x] `GET /v1/rounds/today` retorna null quando não há rodada
  - [x] `POST /v1/rounds/:id/confirm` abre a rodada (pending → open)
  - [x] `POST /v1/rounds/:id/confirm` por não-pagador retorna 403
  - [x] `POST /v1/rounds/:id/cancel` reatribui o pagador ao próximo da fila
  - [x] `POST /v1/rounds/:id/cancel` por não-pagador retorna 403
  - [x] Confirm/Cancel em rodada não-pending retorna 409